### PR TITLE
Specify version of PyJWT

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     packages=find_packages(),
     long_description=read('README.rst'),
     install_requires=[
-        'PyJWT',
+        'PyJWT==0.2.1',
         'oauthlib',
         'requests',
         'requests-oauthlib',


### PR DESCRIPTION
Code in here is incompatible with recent versions of PyJWT.
It should be updated so that it is compatible, but this is
a stopgap in the meantime.

Bug: https://github.com/wikimedia/MediaWiki-OAuth/issues/13