### PR TITLE
Upgrade PyJWT to >=1.0.1<2.0.0, fixes #15 and closes #13

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-PyJWT == 0.2.1
+PyJWT == 1.0.1
 oauthlib == 0.6.1
 requests == 2.2.1
 requests-oauthlib == 0.4.0

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     packages=find_packages(),
     long_description=read('README.rst'),
     install_requires=[
-        'PyJWT==0.2.1',
+        'PyJWT>=1.0.1,<2.0.0',
         'oauthlib',
         'requests',
         'requests-oauthlib',


### PR DESCRIPTION
Fixes the security concerns raised in #15 and the underlying problem of #13.

PyJWT 1.0 verifies the algorithm, audience and `exp` in the jwt,
see pyjwt/api.py:
https://github.com/jpadilla/pyjwt/blob/bd57b024d014faea73e62c3d40f0608418e1f1b0/jwt/api.py#L159-L213

The new catches for the  exceptions aren't really needed,
I added them for consistency with the existing code and clarity.

PyJWT doesn't seem to verify `iat` or `nonce'.